### PR TITLE
Running tests in CI - naively at this point

### DIFF
--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,6 +26,7 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
-    - run: yarn install --frozen-lockfile
-    - run: yarn invoke serve:ci
+    - run: yarn install
+    - run: yarn bootstrap
+    - run: yarn invoke dev
     - run: yarn invoke test

--- a/.github/workflows/node.js.yml
+++ b/.github/workflows/node.js.yml
@@ -26,7 +26,9 @@ jobs:
       with:
         node-version: ${{ matrix.node-version }}
         cache: 'yarn'
+    - run: yarn global add wait-on
     - run: yarn install
     - run: yarn bootstrap
-    - run: yarn invoke dev
+    - run: yarn invoke dev &
+    - run: yarn exec wait-on tcp:3000 && yarn exec wait-on tcp:8080
     - run: yarn invoke test

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "root",
   "private": true,
-  "devDependencies": {
+  "dependencies": {
     "lerna": "^4.0.0"
   },
   "scripts": {

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -18,20 +18,20 @@
     "@types/js-cookie": "^3.0.1",
     "@types/react": "^17.0.39",
     "@types/react-dom": "^17.0.11",
-    "html-webpack-plugin": "^5.5.0",
     "jest": "^27.4.7",
     "puppeteer": "^13.1.2",
     "ts-jest": "^27.1.3",
-    "ts-loader": "^9.2.6",
-    "typescript": "^4.5.5",
-    "webpack": "^5.69.1",
-    "webpack-cli": "^4.9.2",
     "webpack-dev-server": "^4.7.4"
   },
   "dependencies": {
     "axios": "^0.26.0",
     "js-cookie": "^3.0.1",
     "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "react-dom": "^17.0.2",
+    "html-webpack-plugin": "^5.5.0",
+    "ts-loader": "^9.2.6",
+    "typescript": "^4.5.5",
+    "webpack": "^5.69.1",
+    "webpack-cli": "^4.9.2"
   }
 }

--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -6,8 +6,7 @@
   "scripts": {
     "test": "jest",
     "build": "webpack --mode production",
-    "dev": "API_URL=http://localhost:8080 webpack serve --mode development",
-    "serve:ci": "API_URL=http://localhost:8080 webpack serve"
+    "dev": "API_URL=http://localhost:8080 webpack serve --mode development"
   },
   "author": "",
   "license": "ISC",
@@ -21,17 +20,17 @@
     "jest": "^27.4.7",
     "puppeteer": "^13.1.2",
     "ts-jest": "^27.1.3",
-    "webpack-dev-server": "^4.7.4"
-  },
-  "dependencies": {
-    "axios": "^0.26.0",
-    "js-cookie": "^3.0.1",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2",
+    "webpack-dev-server": "^4.7.4",
     "html-webpack-plugin": "^5.5.0",
     "ts-loader": "^9.2.6",
     "typescript": "^4.5.5",
     "webpack": "^5.69.1",
     "webpack-cli": "^4.9.2"
+  },
+  "dependencies": {
+    "axios": "^0.26.0",
+    "js-cookie": "^3.0.1",
+    "react": "^17.0.2",
+    "react-dom": "^17.0.2"
   }
 }

--- a/packages/server/package.json
+++ b/packages/server/package.json
@@ -13,12 +13,12 @@
   "devDependencies": {
     "@types/cors": "^2.8.12",
     "@types/express": "^4.17.13",
-    "nodemon": "^2.0.15",
-    "ts-node": "^10.5.0",
-    "typescript": "^4.5.5"
+    "nodemon": "^2.0.15"
   },
   "dependencies": {
     "cors": "^2.8.5",
-    "express": "^4.17.3"
+    "express": "^4.17.3",
+    "ts-node": "^10.5.0",
+    "typescript": "^4.5.5"
   }
 }


### PR DESCRIPTION
@silicakes I'm probably missing something with how Lerna and Yarn work. I want to get tests running in GitHub action, currently without bundling and dockerizing everything, so I want to use webpack server and ts-node. However, even though I moved the relevant dependencies from `devDependencies` to `dependencies` I still get a `MODULE_NOT_FOUND` error on `html-webpack-plugin`. Can you please take a look?